### PR TITLE
Add debugModeEnabled option to LogMiddleware.

### DIFF
--- a/Source/LogMiddleware.swift
+++ b/Source/LogMiddleware.swift
@@ -28,20 +28,22 @@
 public struct LogMiddleware: MiddlewareType {
     private let log: Log
     private let level: Log.Level
+    private let debugModeEnabled: Bool
 
-    public init(log: Log, level: Log.Level = .Info) {
+    public init(log: Log, level: Log.Level = .Info, debugModeEnabled: Bool = false) {
         self.log = log
         self.level = level
+        self.debugModeEnabled = debugModeEnabled
     }
-
+    
     public func respond(request: Request, chain: ChainType) throws -> Response {
         let response = try chain.proceed(request)
         var message = "================================================================================\n"
         message += "Request:\n"
-        message += "\(request)\n"
+        message += debugModeEnabled ? "\(request.debugDescription)\n" : "\(request)\n"
         message += "--------------------------------------------------------------------------------\n"
         message += "Response:\n"
-        message += "\(response)\n"
+        message += debugModeEnabled ? "\(response.debugDescription)\n" : "\(response)\n"
         message += "================================================================================\n\n"
         log.log(level, item: message)
         return response


### PR DESCRIPTION
This one is related to Zewo/Zewo#49.
This update will have no impact on existing code, because `DebugLogMiddleware` is still there and `debugModeEnabled` has a default value of `false`.
